### PR TITLE
Release/v3.0.0

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,20 @@
       "Bash(dotnet:*)",
       "Bash(git status:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(sed 's/^A\\\\t//')",
+      "Bash(grep \"\\\\.csproj$\")",
+      "Bash(sed 's/^D\\\\t//')",
+      "Bash(git stash:*)",
+      "Bash(git pull:*)",
+      "Bash(python3 -c \":*)",
+      "Bash(for pkg:*)",
+      "Bash(do)",
+      "Bash(echo \"=== $pkg ===\")",
+      "Read(//c/Users/najaf/.nuget/packages/$pkg/**)",
+      "Bash(done)",
+      "Bash(git push:*)",
+      "Bash(git checkout:*)"
     ]
   }
 }

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 2.1.0
+next-version: 3.0.0
 tag-prefix: '[vV]'
 mode: ContinuousDeployment
 branches:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Code Shayk
+Copyright (c) 2026 Code Shayk
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/CodeShayk/DataFuse.Net/blob/master/Images/data-integration-transparent.png" alt="data" style="width:50px;"/> DataFuse
+# <img src="https://github.com/CodeShayk/DataFuse.Net/blob/master/Images/data-integration-transparent.png" alt="data" style="width:50px;"/> DataFuse v3.0.0
 
 ### Like GraphQL, but for your heterogeneous backend systems
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Master-Build](https://github.com/CodeShayk/DataFuse.Net/actions/workflows/Build-Master.yml/badge.svg)](https://github.com/CodeShayk/DataFuse.Net/actions/workflows/Build-Master.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/CodeShayk/DataFuse.Net?logo=github&sort=semver)](https://github.com/CodeShayk/DataFuse.Net/releases/latest)
 [![Master-CodeQL](https://github.com/CodeShayk/DataFuse.Net/actions/workflows/Master-CodeQL.yml/badge.svg)](https://github.com/CodeShayk/DataFuse.Net/actions/workflows/Master-CodeQL.yml)
-[![.Net 9.0](https://img.shields.io/badge/.Net-9.0-blue)](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)
+[![.Net 10.0](https://img.shields.io/badge/.Net-10.0-blue)](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)
 
 **DataFuse** is a declarative framework that aggregates data from SQL databases, REST APIs, and any heterogeneous datsource into unified, strongly-typed objects — replacing hundreds of lines of manual orchestration code with clean, schema-driven configuration.
 
@@ -224,11 +224,12 @@ public class ProductService
 
 | Package | .NET | .NET Standard | .NET Framework |
 |---|---|---|---|
-| DataFuse.Integration | 9.0+ | 2.0, 2.1 | 4.6.2+ |
-| DataFuse.Adapters.SQL | 9.0+ | 2.1 | 4.6.2+ |
-| DataFuse.Adapters.EntityFramework | 9.0+ | - | - |
-| DataFuse.Adapters.WebAPI | 9.0+ | 2.0, 2.1 | 4.6.2+ |
-| DataFuse.Adapters.MongoDB | 9.0+ | - | - |
+| DataFuse.Integration | 8.0, 9.0, 10.0 | 2.1 | - |
+| DataFuse.Adapters.Abstraction | 8.0, 9.0, 10.0 | 2.1 | - |
+| DataFuse.Adapters.SQL | 8.0, 9.0, 10.0 | 2.1 | - |
+| DataFuse.Adapters.WebAPI | 8.0, 9.0, 10.0 | 2.1 | - |
+| DataFuse.Adapters.MongoDB | 8.0, 9.0, 10.0 | 2.1 | - |
+| DataFuse.Adapters.EntityFramework | 10.0 | - | - |
 
 ---
 
@@ -254,9 +255,10 @@ This project is licensed with the [MIT license](LICENSE).
 
 ## Version History
 
-The main branch is now on .NET 9.0. Previous versions:
+The main branch is now on .NET 10.0. Previous versions:
 
 | Version | Release Notes | Developer Guide |
 |---|---|---|
+| [`v3.0.0`](https://github.com/CodeShayk/DataFuse.Net/tree/v3.0.0) | [Notes](https://github.com/CodeShayk/DataFuse.Net/releases/tag/v3.0.0) | [Guide](https://github.com/CodeShayk/DataFuse.Net/blob/v3.0.0/index.md) |
 | [`v2.0.0`](https://github.com/CodeShayk/DataFuse.Net/tree/v2.0.0) | [Notes](https://github.com/CodeShayk/DataFuse.Net/releases/tag/v2.0.0) | [Guide](https://github.com/CodeShayk/DataFuse.Net/blob/v2.0.0/index.md) |
 | [`v1.0.0`](https://github.com/CodeShayk/DataFuse.Net/tree/v1.0.0) | [Notes](https://github.com/CodeShayk/DataFuse.Net/releases/tag/v1.0.0) | [Guide](https://github.com/CodeShayk/DataFuse.Net/blob/v1.0.0/index.md) |

--- a/src/DataFuse.Adapters.Abstraction/DataFuse.Adapters.Abstraction.csproj
+++ b/src/DataFuse.Adapters.Abstraction/DataFuse.Adapters.Abstraction.csproj
@@ -9,13 +9,13 @@
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
-    <RepositoryUrl>https://github.com/CodeShayk/DataFuse</RepositoryUrl>
+    <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ninja-icon-16.png</PackageIcon>
     <Description>DataFuse adapter abstraction layer. Contains interfaces and base classes needed for implementing custom data adapters (SQL, Entity Framework, Web API, etc.).</Description>
     <PackageTags>datafuse adapter abstraction data-mapping query-engine data-mapper schema-mapping data-aggregator</PackageTags>
-    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse/wiki</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Title>DataFuse Adapters Abstraction</Title>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -23,7 +23,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Version>3.0.0</Version>
-    <PackageReleaseNotes> v3.0.0 - Targets .NET 10.
+    <PackageReleaseNotes>v3.0.0
+- Multi-target framework support: netstandard2.1, net8.0, net9.0, net10.0.
+- Added CacheResult attribute for query result caching.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/DataFuse.Adapters.Abstraction/DataFuse.Adapters.Abstraction.csproj
+++ b/src/DataFuse.Adapters.Abstraction/DataFuse.Adapters.Abstraction.csproj
@@ -8,11 +8,11 @@
     <IsPackable>true</IsPackable>
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
-    <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
+    <Copyright>Copyright (c) 2026 Code Shayk</Copyright>
     <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>ninja-icon-16.png</PackageIcon>
+    <PackageIcon>data-integration-transparent.png</PackageIcon>
     <Description>DataFuse adapter abstraction layer. Contains interfaces and base classes needed for implementing custom data adapters (SQL, Entity Framework, Web API, etc.).</Description>
     <PackageTags>datafuse adapter abstraction data-mapping query-engine data-mapper schema-mapping data-aggregator</PackageTags>
     <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\Images\ninja-icon-16.png">
+    <None Include="..\..\Images\data-integration-transparent.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/src/DataFuse.Adapters.EntityFramework/DataFuse.Adapters.EntityFramework.csproj
+++ b/src/DataFuse.Adapters.EntityFramework/DataFuse.Adapters.EntityFramework.csproj
@@ -11,10 +11,10 @@
     <Company>Code Shayk</Company>
     <Description>DataFuse is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. This package provides the Entity Framework adapter for querying databases.</Description>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
-    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse/wiki</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
     <PackageIcon>ninja-icon-16.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/CodeShayk/DataFuse</RepositoryUrl>
+    <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>datafuse data-mapping query-engine data-mapper schema-mapping datafuse-entity-framework entity-framework data-aggregator</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
@@ -23,9 +23,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Version>3.0.0</Version>
-    <PackageReleaseNotes>
-      v3.0.0 - Targets .NET 10.
-      - Provides Pre and Post Transform hooks.
+    <PackageReleaseNotes>v3.0.0
+- Targets .NET 10.0.
+- Pre and Post Transform hooks for data transformation pipeline.
+- Entity Framework Core 10.0 based query execution.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/DataFuse.Adapters.EntityFramework/DataFuse.Adapters.EntityFramework.csproj
+++ b/src/DataFuse.Adapters.EntityFramework/DataFuse.Adapters.EntityFramework.csproj
@@ -10,9 +10,9 @@
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
     <Description>DataFuse is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. This package provides the Entity Framework adapter for querying databases.</Description>
-    <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
+    <Copyright>Copyright (c) 2026 Code Shayk</Copyright>
     <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
-    <PackageIcon>ninja-icon-16.png</PackageIcon>
+    <PackageIcon>data-integration-transparent.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\Images\ninja-icon-16.png">
+    <None Include="..\..\Images\data-integration-transparent.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/src/DataFuse.Adapters.MongoDB/DataFuse.Adapters.MongoDB.csproj
+++ b/src/DataFuse.Adapters.MongoDB/DataFuse.Adapters.MongoDB.csproj
@@ -23,9 +23,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Version>3.0.0</Version>
-    <PackageReleaseNotes>
-      v3.0.0 - Initial release targeting .NET 10.
-      - MongoDB adapter for DataFuse data aggregation framework.
+    <PackageReleaseNotes>v3.0.0
+- New MongoDB adapter for DataFuse data aggregation framework.
+- Multi-target framework support: netstandard2.1, net8.0, net9.0, net10.0.
+- MongoDB Driver 3.4.0 based query execution.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/DataFuse.Adapters.MongoDB/DataFuse.Adapters.MongoDB.csproj
+++ b/src/DataFuse.Adapters.MongoDB/DataFuse.Adapters.MongoDB.csproj
@@ -13,9 +13,9 @@
     <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>ninja-icon-16.png</PackageIcon>
+    <PackageIcon>data-integration-transparent.png</PackageIcon>
     <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
-    <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
+    <Copyright>Copyright (c) 2026 Code Shayk</Copyright>
     <Description>DataFuse is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. This package provides the MongoDB adapter for querying MongoDB collections.</Description>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\Images\ninja-icon-16.png">
+    <None Include="..\..\Images\data-integration-transparent.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/src/DataFuse.Adapters.SQL/DataFuse.Adapters.SQL.csproj
+++ b/src/DataFuse.Adapters.SQL/DataFuse.Adapters.SQL.csproj
@@ -10,11 +10,11 @@
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
     <PackageTags>datafuse data-mapping query-engine data-mapper schema-mapping datafuse-sql dapper-sql dapper data-aggregator</PackageTags>
-    <RepositoryUrl>https://github.com/CodeShayk/DataFuse</RepositoryUrl>
+    <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ninja-icon-16.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse/wiki</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
     <Description>DataFuse is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. This package provides the SQL adapter with Dapper support for querying SQL databases.</Description>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
@@ -23,9 +23,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Version>3.0.0</Version>
-    <PackageReleaseNotes>
-      v3.0.0 - Targets .NET 10.
-      - Provides Pre and Post Transform hooks.
+    <PackageReleaseNotes>v3.0.0
+- Multi-target framework support: netstandard2.1, net8.0, net9.0, net10.0.
+- Pre and Post Transform hooks for data transformation pipeline.
+- Dapper-based SQL query execution.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/DataFuse.Adapters.SQL/DataFuse.Adapters.SQL.csproj
+++ b/src/DataFuse.Adapters.SQL/DataFuse.Adapters.SQL.csproj
@@ -13,9 +13,9 @@
     <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>ninja-icon-16.png</PackageIcon>
+    <PackageIcon>data-integration-transparent.png</PackageIcon>
     <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
-    <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
+    <Copyright>Copyright (c) 2026 Code Shayk</Copyright>
     <Description>DataFuse is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. This package provides the SQL adapter with Dapper support for querying SQL databases.</Description>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\Images\ninja-icon-16.png">
+    <None Include="..\..\Images\data-integration-transparent.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/src/DataFuse.Adapters.WebAPI/DataFuse.Adapters.WebAPI.csproj
+++ b/src/DataFuse.Adapters.WebAPI/DataFuse.Adapters.WebAPI.csproj
@@ -11,10 +11,10 @@
     <Company>Code Shayk</Company>
     <Description>DataFuse is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. This package provides the Web API adapter using HttpClient.</Description>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
-    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse/wiki</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
     <PackageIcon>ninja-icon-16.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/CodeShayk/DataFuse</RepositoryUrl>
+    <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>datafuse data-mapping query-engine data-mapper schema-mapping datafuse-webapi data-aggregator</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
@@ -23,9 +23,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Version>3.0.0</Version>
-    <PackageReleaseNotes>
-      v3.0.0 - Targets .NET 10.
-      - Provides Pre and Post Transform hooks.
+    <PackageReleaseNotes>v3.0.0
+- Multi-target framework support: netstandard2.1, net8.0, net9.0, net10.0.
+- Pre and Post Transform hooks for data transformation pipeline.
+- HttpClient-based Web API query execution.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/DataFuse.Adapters.WebAPI/DataFuse.Adapters.WebAPI.csproj
+++ b/src/DataFuse.Adapters.WebAPI/DataFuse.Adapters.WebAPI.csproj
@@ -10,9 +10,9 @@
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
     <Description>DataFuse is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. This package provides the Web API adapter using HttpClient.</Description>
-    <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
+    <Copyright>Copyright (c) 2026 Code Shayk</Copyright>
     <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
-    <PackageIcon>ninja-icon-16.png</PackageIcon>
+    <PackageIcon>data-integration-transparent.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\Images\ninja-icon-16.png">
+    <None Include="..\..\Images\data-integration-transparent.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/src/DataFuse.Integration/DataFuse.Integration.csproj
+++ b/src/DataFuse.Integration/DataFuse.Integration.csproj
@@ -9,13 +9,13 @@
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
     <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
-    <RepositoryUrl>https://github.com/CodeShayk/DataFuse</RepositoryUrl>
+    <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ninja-icon-16.png</PackageIcon>
     <Description>DataFuse is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings.</Description>
     <PackageTags>graphql data json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch datafuse datafuse-integration data-aggregator</PackageTags>
-    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse/wiki</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Title>DataFuse Integration</Title>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -23,8 +23,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Version>3.0.0</Version>
-    <PackageReleaseNotes> v3.0.0 - Targets .NET 10.
-      - Provides Pre and Post Transform hooks.
+    <PackageReleaseNotes>v3.0.0
+- Multi-target framework support: netstandard2.1, net8.0, net9.0, net10.0.
+- Pre and Post Transform hooks for data transformation pipeline.
+- XPath and JSONPath schema-driven data aggregation.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/DataFuse.Integration/DataFuse.Integration.csproj
+++ b/src/DataFuse.Integration/DataFuse.Integration.csproj
@@ -8,11 +8,11 @@
     <IsPackable>true</IsPackable>
     <Authors>Code Shayk</Authors>
     <Company>Code Shayk</Company>
-    <Copyright>Copyright (c) 2025 Code Shayk</Copyright>
+    <Copyright>Copyright (c) 2026 Code Shayk</Copyright>
     <RepositoryUrl>https://github.com/CodeShayk/DataFuse.Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>ninja-icon-16.png</PackageIcon>
+    <PackageIcon>data-integration-transparent.png</PackageIcon>
     <Description>DataFuse is a powerful .NET library designed to aggregate data from heterogeneous data stores using a schema-driven approach. It enables developers to hydrate complex object graphs by fetching data from multiple sources (SQL databases, Web APIs, NoSQL stores) using XPath and JSONPath schema mappings.</Description>
     <PackageTags>graphql data json-schema xsd data-mapping query-engine data-mapper data-schema schema-mapping object-tree-query object-graph-query schema-mapper xsd-data-object object-graph-data entity-data entity-data-fetch hydrate-object object-hydration object-data object-fetch datafuse datafuse-integration data-aggregator</PackageTags>
     <PackageProjectUrl>https://github.com/CodeShayk/DataFuse.Net/wiki</PackageProjectUrl>
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\Images\ninja-icon-16.png">
+    <None Include="..\..\Images\data-integration-transparent.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>


### PR DESCRIPTION
# DataFuse v3.0.0 Release Notes

**Release Date:** March 30, 2026

DataFuse v3.0.0 is a major release that introduces the new **MongoDB adapter**, **transform hooks**, **query result caching**, and **multi-target framework support**. This release also completes the project rebrand from Schemio to DataFuse, which includes breaking namespace and package changes.

---

## New Features

### MongoDB Adapter

New `DataFuse.Adapters.MongoDB` package for aggregating data from MongoDB collections alongside SQL, REST API, and Entity Framework sources.

- Built on MongoDB Driver 3.4.0
- Implements the same query/engine pattern as other adapters
- Register via `.WithEngine(c => new DataFuse.Adapters.MongoDB.QueryEngine(mongoDatabase))`

```csharp
public class ReviewsMongoQuery : MongoQuery<CollectionResult<ReviewResult>>
{
    protected override Func<IMongoDatabase, Task<CollectionResult<ReviewResult>>> GetQuery(
        IDataContext context, IQueryResult? parentQueryResult)
    {
        var product = (ProductResult)parentQueryResult;
        return async database =>
        {
            var collection = database.GetCollection<ReviewResult>("reviews");
            var reviews = await collection.Find(r => r.ProductId == product.Id).ToListAsync();
            return new CollectionResult<ReviewResult>(reviews);
        };
    }
}
```

### Transform Hooks

Pre and post transformation hooks provide fine-grained control over the data transformation pipeline.

- **PreTransform hooks** execute before a transformation and can cancel it via `context.Cancel()`
- **PostTransform hooks** execute after a transformation and can request repetition via `context.Repeat()`

### Query Result Caching

New `CacheResultAttribute` allows marking expensive query results for automatic caching to improve performance.

### Multi-Target Framework Support

All packages (except EntityFramework) now target multiple frameworks:

- `netstandard2.1`
- `net8.0`
- `net9.0`
- `net10.0`

`DataFuse.Adapters.EntityFramework` targets `net10.0` only (EF Core 10.0 dependency).

---

## Breaking Changes

### Project Rename (Schemio to DataFuse)

All namespaces, packages, and registration APIs have been renamed:

| v2.x (Schemio)             | v3.0.0 (DataFuse)                    |
|-----------------------------|--------------------------------------|
| `Schemio.Core` (contracts)  | `DataFuse.Adapters.Abstraction`      |
| `Schemio.Core` (impl)       | `DataFuse.Integration`               |
| `Schemio.SQL`               | `DataFuse.Adapters.SQL`              |
| `Schemio.EntityFramework`   | `DataFuse.Adapters.EntityFramework`  |
| `Schemio.API`               | `DataFuse.Adapters.WebAPI`           |

### DI Registration

```csharp
// Before (v2.x)
services.UseSchemio(new SchemioOptionsBuilder() ...);

// After (v3.0.0)
services.UseDataFuse(new DataFuseOptionsBuilder() ...);
```

### Interface Renames

- `ISchemioOptions` → `IDataFuseOptions`
- `SchemioOptionsBuilder` → `DataFuseOptionsBuilder`

### NuGet Package Names

All package IDs have changed. Update your package references:

| Old Package            | New Package                          |
|------------------------|--------------------------------------|
| `Schemio.Core`         | `DataFuse.Adapters.Abstraction`      |
| `Schemio.Core`         | `DataFuse.Integration`               |
| `Schemio.SQL`          | `DataFuse.Adapters.SQL`              |
| `Schemio.EntityFramework` | `DataFuse.Adapters.EntityFramework` |
| `Schemio.API`          | `DataFuse.Adapters.WebAPI`           |

---

## Migration Guide

1. **Update NuGet packages** to the new `DataFuse.*` package names
2. **Update `using` statements** from `Schemio.*` namespaces to `DataFuse.*`
3. **Update DI registration** from `UseSchemio()` to `UseDataFuse()` and `SchemioOptionsBuilder` to `DataFuseOptionsBuilder`
4. **Update target framework** if needed — packages now support `netstandard2.1`, `net8.0`, `net9.0`, and `net10.0`

---

## Packages

| Package                              | Version | Frameworks                                   |
|--------------------------------------|---------|----------------------------------------------|
| `DataFuse.Adapters.Abstraction`      | 3.0.0   | netstandard2.1, net8.0, net9.0, net10.0      |
| `DataFuse.Integration`               | 3.0.0   | netstandard2.1, net8.0, net9.0, net10.0      |
| `DataFuse.Adapters.SQL`              | 3.0.0   | netstandard2.1, net8.0, net9.0, net10.0      |
| `DataFuse.Adapters.EntityFramework`  | 3.0.0   | net10.0                                      |
| `DataFuse.Adapters.WebAPI`           | 3.0.0   | netstandard2.1, net8.0, net9.0, net10.0      |
| `DataFuse.Adapters.MongoDB`          | 3.0.0   | netstandard2.1, net8.0, net9.0, net10.0      |

---

## Repository

- **GitHub:** [CodeShayk/DataFuse.Net](https://github.com/CodeShayk/DataFuse.Net)
